### PR TITLE
chore: Add license identifier to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "email": "joan.llenas.maso@gmail.com",
     "url": "http://joanllenas.com"
   },
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/joanllenas/ngx-remotedata/issues"
   },


### PR DESCRIPTION
Helps projects that depend on this reason about license conditions. Better would be to also include an indication of copyright and license in the code itself, protected from removal by webpack and similar tools with `/*! */` but this is the bare minimum needed.