### PR TITLE
fix(linting): Export state interfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-remotedata",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/lib/src/lib/remote-data.ts
+++ b/projects/lib/src/lib/remote-data.ts
@@ -2,22 +2,22 @@ import { Observable } from 'rxjs';
 
 type DefaultError = string;
 
-interface NotAsked {
+export interface NotAsked {
   readonly tag: 'NotAsked';
 }
 
-interface InProgress<T> {
+export interface InProgress<T> {
   readonly tag: 'InProgress';
   readonly value: T | undefined;
 }
 
-interface Failure<E, T> {
+export interface Failure<E, T> {
   readonly tag: 'Failure';
   readonly value: T | undefined;
   error: E;
 }
 
-interface Success<T> {
+export interface Success<T> {
   readonly tag: 'Success';
   readonly value: T;
 }


### PR DESCRIPTION
In some cases Typescript compiler fails in reducers because it throws the next error:

```
TS4076: Parameter 'state' of exported function has or is using name 'Success' from external module ".../node_modules/ngx-remotedata/lib/remote-data" but cannot be named.
```

The error is gone when the state interfaces are exported because Typescript can resolve all type names.

![linting-errors](https://user-images.githubusercontent.com/790704/120454263-04522300-c394-11eb-9a20-bf3f159b1621.png)
